### PR TITLE
remove ssh_tunnel properties because we switched to gcloud metadata

### DIFF
--- a/.templates/google/properties.yml
+++ b/.templates/google/properties.yml
@@ -12,12 +12,6 @@ cloud_provider:
     name: google_cpi
     release: bosh-google-cpi
 
-  ssh_tunnel:
-    port: 22
-    user: (( grab meta.google.ssh_user ))
-    host: (( grab jobs.bosh.networks[0].static_ips[0] ))
-    private_key: (( grab meta.google.private_key ))
-
   properties:
     agent:
       mbus: https://mbus:mbus-password@0.0.0.0:6868


### PR DESCRIPTION
we switched from bosh registry to gcloud instance metada
see also https://github.com/cloudfoundry-incubator/bosh-google-cpi-release/issues/154